### PR TITLE
Raf 045 add processing endpoints for bill sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Bill:
 - PUT - /api/bill/{congressNo}/{billType}/{billNumber}/text
 - PUT - /api/bill/{congressNo}/{billType}/{billNumber}/subjects
 - PUT - /api/bill/{congressNo}/{billType}/{billNumber}/relatedBills
+- PUT - /api/bill/{congressNo}/{billType}/{billNumber}/cosponsors
 
 Committee:
 - PUT - /api/committee/all

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.rankandfile</groupId>
     <artifactId>rank-and-file</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
     <name>Rank and File Application</name>
     <description>Parent POM for Rank and File project modules</description>

--- a/raf-data-loader/pom.xml
+++ b/raf-data-loader/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.rankandfile</groupId>
 		<artifactId>rank-and-file</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/controller/external/BillCoSponsorController.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/controller/external/BillCoSponsorController.java
@@ -1,0 +1,53 @@
+package com.rankandfile.dataloader.controller.external;
+
+import com.rankandfile.dataloader.service.external.bill.BillCoSponsorService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/bill")
+public class BillCoSponsorController {
+
+    private final BillCoSponsorService billCoSponsorService;
+
+    @Autowired
+    public BillCoSponsorController(BillCoSponsorService billCoSponsorService) {
+        this.billCoSponsorService = billCoSponsorService;
+    }
+
+    /**
+     * Loads the committees associated with a specific bill from the external API and saves them to the database.
+     * api.congress.gov endpoint: /bill/{congress}/{billType}/{billNumber}/committees
+     *
+     * @param congressNo The Congress number.
+     * @param billType   The bill type.
+     * @param billNumber The bill number.
+     * @return A confirmation message or error response.
+     */
+    @PutMapping("/{congressNo}/{billType}/{billNumber}/cosponsors")
+    public ResponseEntity<String> loadCoSponsorsForBillNumber(
+            @PathVariable String congressNo,
+            @PathVariable String billType,
+            @PathVariable String billNumber) {
+        log.info("Loading committee data for bill number: {}, congress: {}", billNumber, congressNo);
+        try {
+            billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNumber);
+            return ResponseEntity.ok("Successfully loaded committees for bill number: " + billNumber);
+        } catch (EntityNotFoundException e) {
+            log.error("Bill not found: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Bill not found: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Error loading co-sponsors for bill number {}: {}", billNumber, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to load co-sponsors for bill number: " + billNumber);
+        }
+    }
+}

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/controller/external/BillCoSponsorController.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/controller/external/BillCoSponsorController.java
@@ -24,8 +24,8 @@ public class BillCoSponsorController {
     }
 
     /**
-     * Loads the committees associated with a specific bill from the external API and saves them to the database.
-     * api.congress.gov endpoint: /bill/{congress}/{billType}/{billNumber}/committees
+     * Loads the cosponsors associated with a specific bill from the external API and saves them to the database.
+     * api.congress.gov endpoint: /bill/{congress}/{billType}/{billNumber}/cosponsors
      *
      * @param congressNo The Congress number.
      * @param billType   The bill type.

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/controller/external/BillCoSponsorController.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/controller/external/BillCoSponsorController.java
@@ -37,10 +37,10 @@ public class BillCoSponsorController {
             @PathVariable String congressNo,
             @PathVariable String billType,
             @PathVariable String billNumber) {
-        log.info("Loading committee data for bill number: {}, congress: {}", billNumber, congressNo);
+        log.info("Loading co-sponsor data for bill number: {}, congress: {}", billNumber, congressNo);
         try {
             billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNumber);
-            return ResponseEntity.ok("Successfully loaded committees for bill number: " + billNumber);
+            return ResponseEntity.ok("Successfully loaded co-sponsors for bill number: " + billNumber);
         } catch (EntityNotFoundException e) {
             log.error("Bill not found: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Bill not found: " + e.getMessage());

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/processor/BillByCongressTypeNumberProcessor.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/processor/BillByCongressTypeNumberProcessor.java
@@ -1,17 +1,23 @@
 package com.rankandfile.dataloader.processor;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.rankandfile.dataloader.entity.Bill;
+import com.rankandfile.dataloader.entity.Person;
+import com.rankandfile.dataloader.entity.SponsoredLegislation;
 import com.rankandfile.dataloader.repository.BillRepository;
+import com.rankandfile.dataloader.repository.PersonRepository;
 import com.rankandfile.dataloader.util.IdGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -33,12 +39,17 @@ public class BillByCongressTypeNumberProcessor {
     private static final String FIELD_LAWS = "laws";
     private static final String FIELD_LAW_NUMBER = "number";
     private static final String FIELD_LAW_TYPE = "type";
+    private static final String FIELD_SPONSORS = "sponsors";
+    private static final String FIELD_SPONSOR_TYPE = "Sponsor";
+    private static final String FIELD_BIOGUIDE_ID = "bioguideId";
 
     private final BillRepository billRepository;
+    private final PersonRepository personRepository;
     private final IdGenerator idGenerator;
 
-    public BillByCongressTypeNumberProcessor(BillRepository billRepository, IdGenerator idGenerator) {
+    public BillByCongressTypeNumberProcessor(BillRepository billRepository, PersonRepository personRepository, IdGenerator idGenerator) {
         this.billRepository = billRepository;
+        this.personRepository = personRepository;
         this.idGenerator = idGenerator;
     }
 
@@ -190,6 +201,61 @@ public class BillByCongressTypeNumberProcessor {
             // Laws array is not present
             clearLawFields(bill);
         }
+
+        //Process sponsors array
+        if (billObject.has(FIELD_SPONSORS) && billObject.get(FIELD_SPONSORS).isJsonArray()) {
+            JsonArray sponsorsArray = billObject.getAsJsonArray(FIELD_SPONSORS);
+            if (!sponsorsArray.isEmpty()) {
+                Map<String, SponsoredLegislation> existingLegislationMap =
+                        bill.getSponsorships()
+                                .stream()
+                                .collect(Collectors.toMap(
+                                        leg -> generateKey(bill.getCongress(), bill.getBillNo(), bill.getBillType(), FIELD_SPONSOR_TYPE, leg.getPerson().getPersonId()),
+                                        leg -> leg
+                                ));
+
+                for (JsonElement element : sponsorsArray) {
+                    JsonObject sponsorObj = element.getAsJsonObject();
+                    String personId = getAsString(sponsorObj, FIELD_BIOGUIDE_ID);
+                    if (personId == null) {
+                        log.warn("Cosponsor element missing bioguideId; skipping element: {}", sponsorObj);
+                        continue;
+                    }
+
+                    // Look up the Person for the cosponsor.
+                    Person sponsor = personRepository.findPersonByPersonId(personId);
+                    if (sponsor == null) {
+                        log.warn("Cosponsor with bioguideId {} not found; skipping.", personId);
+                        continue;
+                    }
+
+                    String key = generateKey(bill.getCongress(), bill.getBillNo(), bill.getBillType(), FIELD_SPONSOR_TYPE, personId);
+                    SponsoredLegislation existing = existingLegislationMap.get(key);
+                    if (existing == null) {
+                        log.info("Creating new SponsoredLegislation for Bill ID: {} and Cosponsor ID: {}", bill.getBillId(), personId);
+                        SponsoredLegislation sponsoredLegislation = new SponsoredLegislation();
+                        sponsoredLegislation.setSponLegId(idGenerator.generateSponsLegId());
+                        sponsoredLegislation.setPerson(sponsor);
+                        sponsoredLegislation.setBill(bill);
+                        sponsoredLegislation.setSponsorType(FIELD_SPONSOR_TYPE);
+                        bill.getSponsorships().add(sponsoredLegislation);
+                        // Update map to prevent duplicates within this processing run.
+                        existingLegislationMap.put(key, sponsoredLegislation);
+                    } else {
+                        log.info("SponsoredLegislation relationship already exists for Cosponsor ID: {}", personId);
+                    }
+                }
+            }
+
+        }
+    }
+
+    private String generateKey(String congress, String billNo, String billType, String sponsorType, String personId) {
+        String billNoStr = (billNo != null) ? billNo : "unknownBillNo";
+        String billTypeStr = (billType != null) ? billType : "unknownBillType";
+        String sponsorTypeStr = (sponsorType != null) ? sponsorType : "unknownSponsorType";
+        String personIdStr = (personId != null) ? personId : "unknownPersonId";
+        return congress + "-" + billNoStr + "-" + billTypeStr + "-" + sponsorTypeStr + "-" + personIdStr;
     }
 
     private void clearLawFields(Bill bill) {

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/processor/CoSponsoredLegislationProcessor.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/processor/CoSponsoredLegislationProcessor.java
@@ -1,0 +1,130 @@
+package com.rankandfile.dataloader.processor;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.rankandfile.dataloader.entity.Bill;
+import com.rankandfile.dataloader.entity.Person;
+import com.rankandfile.dataloader.entity.SponsoredLegislation;
+import com.rankandfile.dataloader.repository.PersonRepository;
+import com.rankandfile.dataloader.repository.SponsoredLegislationRepository;
+import com.rankandfile.dataloader.util.IdGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class CoSponsoredLegislationProcessor {
+
+    private static final String FIELD_COSPONSORS = "cosponsors";
+    private static final String FIELD_CO_SPONSOR_TYPE= "Co-Sponsor";
+    private static final String FIELD_BIOGUIDE = "bioguideId";
+
+    private final SponsoredLegislationRepository sponsoredLegislationRepository;
+    private final PersonRepository personRepository;
+    private final IdGenerator idGenerator;
+
+    public CoSponsoredLegislationProcessor(
+            SponsoredLegislationRepository sponsoredLegislationRepository,
+            PersonRepository personRepository,
+            IdGenerator idGenerator) {
+        this.sponsoredLegislationRepository = sponsoredLegislationRepository;
+        this.personRepository = personRepository;
+        this.idGenerator = idGenerator;
+    }
+
+    /**
+     * Processes the new JSON response containing a "cosponsors" array and creates
+     * SponsoredLegislation relationships for the given Bill.
+     *
+     * @param json The JSON string containing the cosponsors data.
+     * @param bill The Bill entity that these cosponsors should be linked to.
+     * @return A list of SponsoredLegislation relationships.
+     */
+    public List<SponsoredLegislation> process(String json, Bill bill) {
+        log.info("Starting processing of cosponsor data for Bill ID: {}", bill.getBillId());
+        JsonObject rootObject;
+        try {
+            rootObject = JsonParser.parseString(json).getAsJsonObject();
+        } catch (Exception e) {
+            log.error("Failed to parse JSON: {}", json, e);
+            return Collections.emptyList();
+        }
+
+        if (!rootObject.has(FIELD_COSPONSORS)) {
+            log.warn("No cosponsors array found in the response.");
+            return Collections.emptyList();
+        }
+
+        JsonArray cosponsorsArray = rootObject.getAsJsonArray(FIELD_COSPONSORS);
+        if (cosponsorsArray == null || cosponsorsArray.isEmpty()) {
+            log.warn("Cosponsors array is empty.");
+            return Collections.emptyList();
+        }
+
+        List<SponsoredLegislation> sponsoredLegislations = new ArrayList<>();
+
+        // Build a map of existing SponsoredLegislation for the given Bill to avoid duplicates.
+        Map<String, SponsoredLegislation> existingLegislationMap = sponsoredLegislationRepository
+                .findByBillBillIdAndSponsorType(bill.getBillId(), FIELD_CO_SPONSOR_TYPE)
+                .stream()
+                .collect(Collectors.toMap(
+                        leg -> generateKey(bill.getCongress(), bill.getBillNo(), bill.getBillType(), FIELD_CO_SPONSOR_TYPE, leg.getPerson().getPersonId()),
+                        leg -> leg
+                ));
+
+        for (JsonElement element : cosponsorsArray) {
+            JsonObject cosponsorObj = element.getAsJsonObject();
+            String cosponsorId = getAsString(cosponsorObj, FIELD_BIOGUIDE);
+            if (cosponsorId == null) {
+                log.warn("Cosponsor element missing bioguideId; skipping element: {}", cosponsorObj);
+                continue;
+            }
+
+            // Look up the Person given the current person id
+            Person cosponsor = personRepository.findPersonByPersonId(cosponsorId);
+            if (cosponsor == null) {
+                log.warn("Cosponsor with bioguideId {} not found; skipping.", cosponsorId);
+                continue;
+            }
+
+            String key = generateKey(bill.getCongress(), bill.getBillNo(), bill.getBillType(), FIELD_CO_SPONSOR_TYPE, cosponsorId);
+            SponsoredLegislation existing = existingLegislationMap.get(key);
+            if (existing == null) {
+                SponsoredLegislation sponsoredLegislation = new SponsoredLegislation();
+                sponsoredLegislation.setSponLegId(idGenerator.generateSponsLegId());
+                sponsoredLegislation.setPerson(cosponsor);
+                sponsoredLegislation.setBill(bill);
+                sponsoredLegislation.setSponsorType(FIELD_CO_SPONSOR_TYPE);
+                sponsoredLegislations.add(sponsoredLegislation);
+                // Update map to prevent duplicates within this processing run.
+                existingLegislationMap.put(key, sponsoredLegislation);
+            } else {
+                log.info("SponsoredLegislation relationship already exists for Cosponsor ID: {}", cosponsorId);
+                sponsoredLegislations.add(existing);
+            }
+        }
+
+        log.info("Completed processing cosponsors for Bill ID: {}. Total relationships created/processed: {}", bill.getBillId(), sponsoredLegislations.size());
+        return sponsoredLegislations;
+    }
+
+    private String getAsString(JsonObject obj, String field) {
+        return obj.has(field) && !obj.get(field).isJsonNull() ? obj.get(field).getAsString() : null;
+    }
+
+    private String generateKey(String congress, String billNo, String billType, String sponsorType, String personId) {
+        String billNoStr = (billNo != null) ? billNo : "unknownBillNo";
+        String billTypeStr = (billType != null) ? billType : "unknownBillType";
+        String sponsorTypeStr = (sponsorType != null) ? sponsorType : "unknownSponsorType";
+        String personIdStr = (personId != null) ? personId : "unknownPersonId";
+        return congress + "-" + billNoStr + "-" + billTypeStr + "-" + sponsorTypeStr + "-" + personIdStr;
+    }
+}

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/repository/SponsoredLegislationRepository.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/repository/SponsoredLegislationRepository.java
@@ -14,6 +14,8 @@ public interface SponsoredLegislationRepository extends JpaRepository<SponsoredL
 
     List<SponsoredLegislation> findByPersonPersonIdAndSponsorType(String personId, String sponsorType);
 
+    List<SponsoredLegislation> findByBillBillIdAndSponsorType(String billBillId, String sponsorType);
+
     @Query("SELECT sl FROM SponsoredLegislation sl JOIN FETCH sl.bill WHERE sl.person.personId = :personId AND sl.sponsorType = :sponsorType")
     Page<SponsoredLegislation> findByPerson_PersonIdAndSponsorType(String personId, String sponsorType, Pageable pageable);
 

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillByTypeAndNumberService.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillByTypeAndNumberService.java
@@ -6,6 +6,7 @@ import com.rankandfile.dataloader.repository.BillRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
@@ -25,6 +26,7 @@ public class BillByTypeAndNumberService {
         this.billByCongressTypeNumberProcessor = billByCongressTypeNumberProcessor;
     }
 
+    @Transactional
     public Bill getBillByTypeAndNumber(String congressNo, String billType, String billNo) {
 
         try {

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillCoSponsorService.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillCoSponsorService.java
@@ -1,0 +1,79 @@
+package com.rankandfile.dataloader.service.external.bill;
+
+import com.rankandfile.dataloader.entity.Bill;
+import com.rankandfile.dataloader.entity.SponsoredLegislation;
+import com.rankandfile.dataloader.processor.SponsoredLegislationProcessor;
+import com.rankandfile.dataloader.repository.BillRepository;
+import com.rankandfile.dataloader.repository.SponsoredLegislationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class BillCoSponsorService {
+
+    private final WebClient webClient;
+    private final BillRepository billRepository;
+    private final SponsoredLegislationRepository sponsoredLegislationRepository;
+    private final SponsoredLegislationProcessor sponsoredLegislationProcessor;
+
+    public BillCoSponsorService(
+            @Qualifier("congressGovApiWebClient") WebClient webClient,
+            BillRepository billRepository, SponsoredLegislationRepository sponsoredLegislationRepository,
+            SponsoredLegislationProcessor sponsoredLegislationProcessor){
+        this.webClient = webClient;
+        this.billRepository = billRepository;
+        this.sponsoredLegislationRepository = sponsoredLegislationRepository;
+        this.sponsoredLegislationProcessor = sponsoredLegislationProcessor;
+    }
+
+    /**
+     * Fetches and processes co-sponsors associated with a specific bill.
+     *
+     * @param congressNo The Congress number.
+     * @param billType   The type of the bill (e.g., "hr", "s").
+     * @param billNo     The bill number.
+     */
+    public void getCoSponsorsByBillNumber(String congressNo, String billType, String billNo) {
+        Bill bill = billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType);
+        if (bill == null) {
+            log.warn("Bill not found for Congress number: {}, Bill number: {}, Bill Type: {}", congressNo, billNo, billType);
+            return;
+        }
+
+        log.info("Starting to fetch co-sponsors for Bill number: {}, Congress: {}, Bill Type: {}", billNo, congressNo, billType);
+
+        try {
+            String response = fetchCoSponsors(congressNo, billType, billNo);
+
+            if (response == null || response.isEmpty()) {
+                log.warn("Received empty response for committees of Bill number: {}, Congress: {}, Bill Type: {}", billNo, congressNo, billType);
+                return;
+            }
+
+            List<SponsoredLegislation> sponsoredLegislationList = sponsoredLegislationProcessor.process(response, bill);
+
+            log.info("CoSponsors successfully updated for Bill ID: {}", bill.getBillId());
+            billRepository.save(bill);
+            sponsoredLegislationRepository.saveAll(sponsoredLegislationList);
+            log.info("CoSponsors successfully saved for Bill ID: {}", bill.getBillId());
+
+        } catch (Exception e) {
+            log.error("An error occurred while fetching CoSponsors for Congress number: {}, Bill number: {}, Bill Type: {}", congressNo, billNo, billType, e);
+            throw e;
+        }
+    }
+
+    private String fetchCoSponsors(String congressNo, String billType, String billNo) {
+        return this.webClient.get()
+                .uri(uriBuilder -> uriBuilder.path("bill/{congressNo}/{billType}/{billNumber}/cosponsors")
+                        .build(congressNo, billType.toLowerCase(), billNo))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillCoSponsorService.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillCoSponsorService.java
@@ -2,7 +2,7 @@ package com.rankandfile.dataloader.service.external.bill;
 
 import com.rankandfile.dataloader.entity.Bill;
 import com.rankandfile.dataloader.entity.SponsoredLegislation;
-import com.rankandfile.dataloader.processor.SponsoredLegislationProcessor;
+import com.rankandfile.dataloader.processor.CoSponsoredLegislationProcessor;
 import com.rankandfile.dataloader.repository.BillRepository;
 import com.rankandfile.dataloader.repository.SponsoredLegislationRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -19,16 +19,16 @@ public class BillCoSponsorService {
     private final WebClient webClient;
     private final BillRepository billRepository;
     private final SponsoredLegislationRepository sponsoredLegislationRepository;
-    private final SponsoredLegislationProcessor sponsoredLegislationProcessor;
+    private final CoSponsoredLegislationProcessor coSponsoredLegislationProcessor;
 
     public BillCoSponsorService(
             @Qualifier("congressGovApiWebClient") WebClient webClient,
             BillRepository billRepository, SponsoredLegislationRepository sponsoredLegislationRepository,
-            SponsoredLegislationProcessor sponsoredLegislationProcessor){
+            CoSponsoredLegislationProcessor coSponsoredLegislationProcessor){
         this.webClient = webClient;
         this.billRepository = billRepository;
         this.sponsoredLegislationRepository = sponsoredLegislationRepository;
-        this.sponsoredLegislationProcessor = sponsoredLegislationProcessor;
+        this.coSponsoredLegislationProcessor = coSponsoredLegislationProcessor;
     }
 
     /**
@@ -55,7 +55,7 @@ public class BillCoSponsorService {
                 return;
             }
 
-            List<SponsoredLegislation> sponsoredLegislationList = sponsoredLegislationProcessor.process(response, bill);
+            List<SponsoredLegislation> sponsoredLegislationList = coSponsoredLegislationProcessor.process(response, bill);
 
             log.info("CoSponsors successfully updated for Bill ID: {}", bill.getBillId());
             billRepository.save(bill);

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillCommitteeService.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/external/bill/BillCommitteeService.java
@@ -32,6 +32,7 @@ public class BillCommitteeService {
      * @param billType   The type of the bill (e.g., "hr", "s").
      * @param billNo     The bill number.
      */
+    //TODO: refactor service to pass bill object to processor to avoid another excessive db call
     public void getCommitteesByBillNumber(String congressNo, String billType, String billNo) {
         // Find the bill in the repository
         Bill bill = billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType);

--- a/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/scheduled/ScheduledBillHydrationRunner.java
+++ b/raf-data-loader/src/main/java/com/rankandfile/dataloader/service/scheduled/ScheduledBillHydrationRunner.java
@@ -28,6 +28,7 @@ public class ScheduledBillHydrationRunner {
     private final BillTextService billTextService;
     private final BillSubjectService billSubjectService;
     private final RelatedBillService relatedBillService;
+    private final BillCoSponsorService billCoSponsorService;
 
     private final int limit = 250;
 
@@ -35,7 +36,7 @@ public class ScheduledBillHydrationRunner {
     private final RateLimiter rateLimiter = RateLimiter.create(1.388);
 
     /**
-     * Hydrates all 7 bill endpoints where the update timestamp is within the last hour
+     * Hydrates all 8 bill endpoints where the update timestamp is within the last hour
      * Time to calculate against is passed from initial service
      * Called every day at the top of every hour
      */
@@ -52,7 +53,7 @@ public class ScheduledBillHydrationRunner {
             return;
         }
 
-        int maxBillsPerHour = 650; // Safety margin (650 bills * 7 calls = 4550 calls) to stay under 5k rate limit
+        int maxBillsPerHour = 600; // Safety margin (600 bills * 8 calls = 4800 calls) to stay under 5k rate limit
         int totalBills = recentBills.size();
         int totalBatches = (int) Math.ceil((double) totalBills / maxBillsPerHour);
 
@@ -121,6 +122,7 @@ public class ScheduledBillHydrationRunner {
         callServiceWithRateLimit(() -> billTextService.fetchBillTexts(congressNo, billType, billNo));
         callServiceWithRateLimit(() -> billSubjectService.fetchBillSubjects(congressNo, billType, billNo));
         callServiceWithRateLimit(() -> relatedBillService.getRelatedBills(congressNo, billType, billNo));
+        callServiceWithRateLimit(() -> billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNo));
     }
 
     /**

--- a/raf-data-loader/src/test/java/com/rankandfile/dataloader/controller/BillCoSponsorControllerTest.java
+++ b/raf-data-loader/src/test/java/com/rankandfile/dataloader/controller/BillCoSponsorControllerTest.java
@@ -1,0 +1,77 @@
+package com.rankandfile.dataloader.controller;
+
+import com.rankandfile.dataloader.controller.external.BillCoSponsorController;
+import com.rankandfile.dataloader.service.external.bill.BillCoSponsorService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(BillCoSponsorController.class)
+class BillCoSponsorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BillCoSponsorService billCoSponsorService;
+
+    @Test
+    void testLoadCoSponsorsForBillNumberSuccess() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNumber = "1234";
+
+        mockMvc.perform(put("/api/bill/{congressNo}/{billType}/{billNumber}/cosponsors", congressNo, billType, billNumber)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Successfully loaded committees for bill number: " + billNumber));
+
+        Mockito.verify(billCoSponsorService, times(1)).getCoSponsorsByBillNumber(congressNo, billType, billNumber);
+    }
+
+    @Test
+    void testLoadCoSponsorsForBillNumberBillNotFound() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNumber = "9999";
+
+        Mockito.doThrow(new EntityNotFoundException("Bill not found"))
+                .when(billCoSponsorService).getCoSponsorsByBillNumber(congressNo, billType, billNumber);
+
+        mockMvc.perform(put("/api/bill/{congressNo}/{billType}/{billNumber}/cosponsors", congressNo, billType, billNumber)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string("Bill not found: Bill not found"));
+
+        Mockito.verify(billCoSponsorService, times(1)).getCoSponsorsByBillNumber(congressNo, billType, billNumber);
+    }
+
+    @Test
+    void testLoadCoSponsorsForBillNumberInternalServerError() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNumber = "1234";
+
+        Mockito.doThrow(new RuntimeException("Unexpected error"))
+                .when(billCoSponsorService).getCoSponsorsByBillNumber(congressNo, billType, billNumber);
+
+        mockMvc.perform(put("/api/bill/{congressNo}/{billType}/{billNumber}/cosponsors", congressNo, billType, billNumber)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().string("Failed to load co-sponsors for bill number: " + billNumber));
+
+        Mockito.verify(billCoSponsorService, times(1)).getCoSponsorsByBillNumber(congressNo, billType, billNumber);
+    }
+}

--- a/raf-data-loader/src/test/java/com/rankandfile/dataloader/processor/CoSponsoredLegislationProcessorTest.java
+++ b/raf-data-loader/src/test/java/com/rankandfile/dataloader/processor/CoSponsoredLegislationProcessorTest.java
@@ -1,0 +1,206 @@
+package com.rankandfile.dataloader.processor;
+
+import com.rankandfile.dataloader.entity.Bill;
+import com.rankandfile.dataloader.entity.Person;
+import com.rankandfile.dataloader.entity.SponsoredLegislation;
+import com.rankandfile.dataloader.repository.PersonRepository;
+import com.rankandfile.dataloader.repository.SponsoredLegislationRepository;
+import com.rankandfile.dataloader.util.IdGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CoSponsoredLegislationProcessorTest {
+
+    @Mock
+    private SponsoredLegislationRepository sponsoredLegislationRepository;
+
+    @Mock
+    private PersonRepository personRepository;
+
+    @Mock
+    private IdGenerator idGenerator;
+
+    @InjectMocks
+    private CoSponsoredLegislationProcessor coSponsoredLegislationProcessor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testProcessWithValidCosponsors() {
+        Bill bill = new Bill();
+        bill.setBillId("BILL-XYZ");
+        bill.setCongress("117");
+        bill.setBillNo("1234");
+        bill.setBillType("H.R.");
+
+        String json = "{\n" +
+                "  \"cosponsors\": [\n" +
+                "    { \"bioguideId\": \"P1234\" },\n" +
+                "    { \"bioguideId\": \"P5678\" }\n" +
+                "  ]\n" +
+                "}";
+
+        // Existing relationships in DB (empty for this test, so all are new)
+        when(sponsoredLegislationRepository.findByBillBillIdAndSponsorType("BILL-XYZ", "Co-Sponsor"))
+                .thenReturn(Collections.emptyList());
+
+        // Mock persons found in DB
+        Person person1 = new Person();
+        person1.setPersonId("P1234");
+
+        Person person2 = new Person();
+        person2.setPersonId("P5678");
+
+        when(personRepository.findPersonByPersonId("P1234")).thenReturn(person1);
+        when(personRepository.findPersonByPersonId("P5678")).thenReturn(person2);
+
+        // Mock ID generator
+        when(idGenerator.generateSponsLegId())
+                .thenReturn("SponsLeg-1", "SponsLeg-2");
+
+        List<SponsoredLegislation> result = coSponsoredLegislationProcessor.process(json, bill);
+
+        verify(sponsoredLegislationRepository)
+                .findByBillBillIdAndSponsorType("BILL-XYZ", "Co-Sponsor");
+
+        // We expect two new relationships because none existed before
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        // Verify that each new SponsoredLegislation has the correct data
+        SponsoredLegislation sponsored1 = result.get(0);
+        assertEquals("SponsLeg-1", sponsored1.getSponLegId());
+        assertEquals(person1, sponsored1.getPerson());
+        assertEquals(bill, sponsored1.getBill());
+        assertEquals("Co-Sponsor", sponsored1.getSponsorType());
+
+        SponsoredLegislation sponsored2 = result.get(1);
+        assertEquals("SponsLeg-2", sponsored2.getSponLegId());
+        assertEquals(person2, sponsored2.getPerson());
+        assertEquals(bill, sponsored2.getBill());
+        assertEquals("Co-Sponsor", sponsored2.getSponsorType());
+    }
+
+    @Test
+    void testProcessWithNoCosponsorsField() {
+        Bill bill = new Bill();
+        bill.setBillId("BILL-XYZ");
+        String json = "{ }"; // no "cosponsors" field
+
+        List<SponsoredLegislation> result = coSponsoredLegislationProcessor.process(json, bill);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        // No repository interactions expected
+        verifyNoInteractions(sponsoredLegislationRepository, personRepository);
+    }
+
+    @Test
+    void testProcessWithEmptyCosponsorsArray() {
+        Bill bill = new Bill();
+        bill.setBillId("BILL-XYZ");
+        String json = "{ \"cosponsors\": [] }";
+
+        List<SponsoredLegislation> result = coSponsoredLegislationProcessor.process(json, bill);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verifyNoMoreInteractions(sponsoredLegislationRepository, personRepository);
+    }
+
+    @Test
+    void testProcessWithInvalidJson() {
+        Bill bill = new Bill();
+        bill.setBillId("BILL-XYZ");
+        String invalidJson = "{ \"cosponsors\": [ ";
+
+        List<SponsoredLegislation> result = coSponsoredLegislationProcessor.process(invalidJson, bill);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(sponsoredLegislationRepository, personRepository);
+    }
+
+    @Test
+    void testProcessWithExistingRelationship() {
+        Bill bill = new Bill();
+        bill.setBillId("BILL-XYZ");
+        bill.setCongress("117");
+        bill.setBillNo("1234");
+        bill.setBillType("H.R.");
+
+        String json = "{\n" +
+                "  \"cosponsors\": [\n" +
+                "    { \"bioguideId\": \"P1234\" }\n" +
+                "  ]\n" +
+                "}";
+
+        // Existing relationship in DB
+        Person existingPerson = new Person();
+        existingPerson.setPersonId("P1234");
+
+        SponsoredLegislation existingSl = new SponsoredLegislation();
+        existingSl.setSponLegId("SponsLeg-Existing");
+        existingSl.setPerson(existingPerson);
+        existingSl.setBill(bill);
+        existingSl.setSponsorType("Co-Sponsor");
+
+        when(sponsoredLegislationRepository.findByBillBillIdAndSponsorType("BILL-XYZ", "Co-Sponsor"))
+                .thenReturn(Collections.singletonList(existingSl));
+
+        when(personRepository.findPersonByPersonId("P1234")).thenReturn(existingPerson);
+
+        List<SponsoredLegislation> result = coSponsoredLegislationProcessor.process(json, bill);
+
+        // Relationship already exists, so no new entity should be created
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("SponsLeg-Existing", result.get(0).getSponLegId());
+
+        verify(sponsoredLegislationRepository).findByBillBillIdAndSponsorType("BILL-XYZ", "Co-Sponsor");
+        verify(personRepository).findPersonByPersonId("P1234");
+        verifyNoMoreInteractions(sponsoredLegislationRepository);
+    }
+
+    @Test
+    void testProcessWithUnknownCosponsor() {
+        Bill bill = new Bill();
+        bill.setBillId("BILL-XYZ");
+        bill.setCongress("117");
+        bill.setBillNo("1234");
+        bill.setBillType("H.R.");
+
+        String json = "{\n" +
+                "  \"cosponsors\": [\n" +
+                "    { \"bioguideId\": \"UNKNOWN\" }\n" +
+                "  ]\n" +
+                "}";
+
+        // No existing relationships
+        when(sponsoredLegislationRepository.findByBillBillIdAndSponsorType("BILL-XYZ", "Co-Sponsor"))
+                .thenReturn(Collections.emptyList());
+
+        // Unknown cosponsor in PersonRepository
+        when(personRepository.findPersonByPersonId("UNKNOWN")).thenReturn(null);
+
+        List<SponsoredLegislation> result = coSponsoredLegislationProcessor.process(json, bill);
+
+        assertNotNull(result);
+        // Should skip creation because Person is not found
+        assertTrue(result.isEmpty());
+
+        verify(sponsoredLegislationRepository)
+                .findByBillBillIdAndSponsorType("BILL-XYZ", "Co-Sponsor");
+        verify(personRepository).findPersonByPersonId("UNKNOWN");
+        verifyNoMoreInteractions(sponsoredLegislationRepository, personRepository);
+    }
+}

--- a/raf-data-loader/src/test/java/com/rankandfile/dataloader/service/BillCoSponsorServiceTest.java
+++ b/raf-data-loader/src/test/java/com/rankandfile/dataloader/service/BillCoSponsorServiceTest.java
@@ -1,0 +1,249 @@
+package com.rankandfile.dataloader.service;
+
+import com.rankandfile.dataloader.entity.Bill;
+import com.rankandfile.dataloader.entity.SponsoredLegislation;
+import com.rankandfile.dataloader.processor.CoSponsoredLegislationProcessor;
+import com.rankandfile.dataloader.repository.BillRepository;
+import com.rankandfile.dataloader.repository.SponsoredLegislationRepository;
+import com.rankandfile.dataloader.service.external.bill.BillCoSponsorService;
+import okhttp3.mockwebserver.*;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import org.springframework.web.reactive.function.client.*;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BillCoSponsorServiceTest {
+
+    private MockWebServer mockWebServer;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private BillRepository billRepository;
+
+    @Mock
+    private SponsoredLegislationRepository sponsoredLegislationRepository;
+
+    @Mock
+    private CoSponsoredLegislationProcessor coSponsoredLegislationProcessor;
+
+    private BillCoSponsorService billCoSponsorService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        String baseUrl = mockWebServer.url("/").toString();
+
+        // Build the WebClient using the baseUrl of the mock server
+        WebClient.Builder webClientBuilder = WebClient.builder()
+                .baseUrl(baseUrl)
+                .filter(addApiKeyQueryParamFilter());
+
+        this.webClient = webClientBuilder.build();
+
+        billCoSponsorService = new BillCoSponsorService(
+                this.webClient,
+                billRepository,
+                sponsoredLegislationRepository,
+                coSponsoredLegislationProcessor
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    /**
+     * Adds an API key as a query param to mimic the reference code's approach.
+     */
+    private ExchangeFilterFunction addApiKeyQueryParamFilter() {
+        return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+            URI updatedUri = UriComponentsBuilder.fromUri(clientRequest.url())
+                    .queryParam("api_key", "test_api_key")
+                    .build(true)
+                    .toUri();
+
+            ClientRequest updatedRequest = ClientRequest.from(clientRequest)
+                    .url(updatedUri)
+                    .build();
+
+            return Mono.just(updatedRequest);
+        });
+    }
+
+    @Test
+    void testGetCoSponsorsByBillNumberBillNotFound() {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNo = "1234";
+
+        when(billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType))
+                .thenReturn(null);
+
+        billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNo);
+
+        verify(billRepository)
+                .findByCongressAndBillNoAndBillType(congressNo, billNo, billType);
+        verifyNoInteractions(coSponsoredLegislationProcessor);
+        verifyNoInteractions(sponsoredLegislationRepository);
+        assertEquals(0, mockWebServer.getRequestCount());
+    }
+
+    @Test
+    void testGetCoSponsorsByBillNumberEmptyResponse() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNo = "1234";
+
+        Bill bill = new Bill();
+        bill.setBillId("BILL-1234");
+
+        when(billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType))
+                .thenReturn(bill);
+
+        // Mock a server response with an empty body
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("")
+                .addHeader("Content-Type", "application/json"));
+
+        billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNo);
+
+        verify(billRepository)
+                .findByCongressAndBillNoAndBillType(congressNo, billNo, billType);
+        verifyNoInteractions(coSponsoredLegislationProcessor);
+        verify(sponsoredLegislationRepository, never()).saveAll(any());
+        verify(billRepository, never()).save(any());
+
+        // Verify request to MockWebServer
+        RecordedRequest recordedRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(recordedRequest, "No request was made to the MockWebServer");
+        assertTrue(recordedRequest.getPath().contains("/cosponsors"));
+    }
+
+    @Test
+    void testGetCoSponsorsByBillNumberExceptionDuringFetch() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNo = "1234";
+
+        Bill bill = new Bill();
+        bill.setBillId("BILL-1234");
+
+        when(billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType))
+                .thenReturn(bill);
+
+        // Enqueue a response with a 500 status to simulate an error
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal Server Error")
+                .addHeader("Content-Type", "application/json"));
+
+        Exception exception = assertThrows(Exception.class,
+                () -> billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNo));
+
+        assertNotNull(exception);
+        verify(billRepository)
+                .findByCongressAndBillNoAndBillType(congressNo, billNo, billType);
+        verifyNoInteractions(coSponsoredLegislationProcessor);
+        verify(sponsoredLegislationRepository, never()).saveAll(any());
+        verify(billRepository, never()).save(any());
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(recordedRequest, "No request was made to the MockWebServer");
+    }
+
+    @Test
+    void testGetCoSponsorsByBillNumberExceptionDuringProcessing() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNo = "1234";
+
+        Bill bill = new Bill();
+        bill.setBillId("BILL-1234");
+
+        when(billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType))
+                .thenReturn(bill);
+
+        // Mock a valid JSON response
+        String responseBody = "{ \"cosponsors\": [ {\"bioguideId\": \"P1234\"} ] }";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(responseBody)
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock processor to throw an exception
+        doThrow(new RuntimeException("Processing error"))
+                .when(coSponsoredLegislationProcessor).process(responseBody, bill);
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNo));
+
+        assertNotNull(exception);
+        assertEquals("Processing error", exception.getMessage());
+        verify(billRepository)
+                .findByCongressAndBillNoAndBillType(congressNo, billNo, billType);
+        verify(coSponsoredLegislationProcessor).process(responseBody, bill);
+        verifyNoInteractions(sponsoredLegislationRepository);
+        verify(billRepository, never()).save(any());
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(recordedRequest, "No request was made to the MockWebServer");
+    }
+
+    @Test
+    void testGetCoSponsorsByBillNumberSuccess() throws Exception {
+        String congressNo = "117";
+        String billType = "hr";
+        String billNo = "1234";
+
+        Bill bill = new Bill();
+        bill.setBillId("BILL-1234");
+        bill.setBillNo(billNo);
+        bill.setBillType(billType);
+        bill.setCongress(congressNo);
+
+        when(billRepository.findByCongressAndBillNoAndBillType(congressNo, billNo, billType))
+                .thenReturn(bill);
+
+        String responseBody = "{ \"cosponsors\": [ {\"bioguideId\": \"P1234\"}, {\"bioguideId\": \"P5678\"} ] }";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(responseBody)
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock the processor to return a list of SponsoredLegislation
+        SponsoredLegislation sl1 = new SponsoredLegislation();
+        sl1.setSponLegId("SL-1");
+
+        SponsoredLegislation sl2 = new SponsoredLegislation();
+        sl2.setSponLegId("SL-2");
+
+        List<SponsoredLegislation> slList = List.of(sl1, sl2);
+        when(coSponsoredLegislationProcessor.process(responseBody, bill)).thenReturn(slList);
+
+        billCoSponsorService.getCoSponsorsByBillNumber(congressNo, billType, billNo);
+
+        verify(billRepository)
+                .findByCongressAndBillNoAndBillType(congressNo, billNo, billType);
+        verify(coSponsoredLegislationProcessor).process(responseBody, bill);
+        verify(billRepository).save(bill);
+        verify(sponsoredLegislationRepository).saveAll(slList);
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(recordedRequest, "No request was made to the MockWebServer");
+        assertTrue(recordedRequest.getPath().contains("/cosponsors"));
+    }
+}

--- a/raf-data-loader/src/test/java/com/rankandfile/dataloader/service/MembersServiceTest.java
+++ b/raf-data-loader/src/test/java/com/rankandfile/dataloader/service/MembersServiceTest.java
@@ -74,7 +74,8 @@ class MembersServiceTest {
     void testFetchAndSaveMembersSuccessfulRetrieval() throws Exception {
         int limit = 2;
         String responsePage1 = "{\"members\": [{}, {}]}"; // Simulated JSON response
-        String responsePage2 = "{\"members\": [{}]}";     // Less than limit to stop pagination
+        String responsePage2 = "{\"members\": [{}]}"; // Less than limit to stop pagination
+        String responsePage3 = "";
 
         // Enqueue mock responses
         mockWebServer.enqueue(new MockResponse()
@@ -82,6 +83,9 @@ class MembersServiceTest {
                 .addHeader("Content-Type", "application/json"));
         mockWebServer.enqueue(new MockResponse()
                 .setBody(responsePage2)
+                .addHeader("Content-Type", "application/json"));
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(responsePage3)
                 .addHeader("Content-Type", "application/json"));
 
         // Mocking CongressMemberProcessor behavior

--- a/raf-frontend/app/bills/[billId]/page.tsx
+++ b/raf-frontend/app/bills/[billId]/page.tsx
@@ -389,7 +389,9 @@ export default async function BillPage({
                               </Link>
                               <div className="flex items-center gap-2">
                                 <span className="text-sm text-muted-foreground">
-                                  {cosponsor.person?.state}-{cosponsor.person?.currentDistrict}{getNumberSuffix(cosponsor.person?.currentDistrict)}
+                                  {cosponsor.person?.state === "District of Columbia"
+                                      ? "D.C."
+                                      : `${cosponsor.person?.state}-${cosponsor.person?.currentDistrict}${getNumberSuffix(cosponsor.person?.currentDistrict)}`}
                                 </span>
                                 <Badge variant={getPartyBadgeVariant(cosponsor.person?.partyMembership)}>
                                   {cosponsor.person?.partyMembership}


### PR DESCRIPTION
Created new endpoint to load cosponsors during bill hydration as well as added ability to add sponsors during bill processing. added e2e tests for new controller, service, and processor. added minor todo comments, upped pom version, and added new endpoint to readme